### PR TITLE
golang updated to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.18
 
 WORKDIR /app
 


### PR DESCRIPTION
This fixes this error when building using docker:
# github.com/staticbackendhq/core/internal
../internal/volatilizer.go:8:25: undefined: any
../internal/volatilizer.go:9:25: undefined: any
../internal/volatilizer.go:14:41: undefined: any
note: module requires Go 1.18