### PR TITLE
feature: add endpoint for db bulk update

### DIFF
--- a/database/memory/base_test.go
+++ b/database/memory/base_test.go
@@ -208,6 +208,46 @@ func TestUpdateDocument(t *testing.T) {
 	}
 }
 
+func TestUpdateDocuments(t *testing.T) {
+	task1 := newTask("should be completed", false)
+	task2 := newTask("should be completed", false)
+
+	var many []interface{}
+	many = append(many, task1)
+	many = append(many, task2)
+
+	if err := datastore.BulkCreateDocument(adminAuth, confDBName, colName, many); err != nil {
+		t.Fatal(err)
+	}
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "should be completed"})
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateFields := map[string]any{"done": true}
+	n, err := datastore.UpdateDocuments(adminAuth, confDBName, colName, filters, updateFields)
+	if err != nil {
+		t.Errorf("The documents are not updated because of an error\nExpected err = nil\nActual err: %s", err.Error())
+	}
+	if n != int64(len(many)) {
+		t.Errorf("The incorrect number of documents are updated\nExpected: %v\nActual: %v", len(many), n)
+	}
+
+	docs, err := datastore.QueryDocuments(adminAuth, confDBName, colName, filters, internal.ListParams{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range docs.Results {
+		got := dec(v)
+		if !got.Done {
+			t.Errorf("The '%s' task is not updated; It should be completed (done=true)", got.Title)
+		}
+	}
+}
+
 func TestIncrementValue(t *testing.T) {
 	task1 := newTask("incr", false)
 	m, err := datastore.CreateDocument(adminAuth, confDBName, colName, task1)

--- a/database/memory/memory.go
+++ b/database/memory/memory.go
@@ -132,6 +132,46 @@ func filter[T any](list []T, fn func(x T) bool) []T {
 	return results
 }
 
+func filterByClauses(list []map[string]any, filter map[string]any) (filtered []map[string]any) {
+	for _, doc := range list {
+		matches := 0
+		for k, v := range filter {
+			op, field := extractOperatorAndValue(k)
+			switch op {
+			case "=":
+				if equal(doc[field], v) {
+					matches++
+				}
+			case "!=":
+				if notEqual(doc[field], v) {
+					matches++
+				}
+			case ">":
+				if greater(doc[field], v) {
+					matches++
+				}
+			case "<":
+				if lower(doc[field], v) {
+					matches++
+				}
+			case ">=":
+				if greaterThanEqual(doc[field], v) {
+					matches++
+				}
+			case "<=":
+				if lowerThanEqual(doc[field], v) {
+					matches++
+				}
+			}
+		}
+
+		if matches == len(filter) {
+			filtered = append(filtered, doc)
+		}
+	}
+	return
+}
+
 func sortSlice[T any](list []T, fn func(a, b T) bool) []T {
 	sort.Slice(list, func(i, j int) bool {
 		return fn(list[i], list[j])

--- a/database/mongo/base_test.go
+++ b/database/mongo/base_test.go
@@ -208,6 +208,46 @@ func TestUpdateDocument(t *testing.T) {
 	}
 }
 
+func TestUpdateDocuments(t *testing.T) {
+	task1 := newTask("should be completed", false)
+	task2 := newTask("should be completed", false)
+
+	var many []interface{}
+	many = append(many, task1)
+	many = append(many, task2)
+
+	if err := datastore.BulkCreateDocument(adminAuth, confDBName, colName, many); err != nil {
+		t.Fatal(err)
+	}
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "should be completed"})
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateFields := map[string]any{"done": true}
+	n, err := datastore.UpdateDocuments(adminAuth, confDBName, colName, filters, updateFields)
+	if err != nil {
+		t.Errorf("The documents are not updated because of an error\nExpected err = nil\nActual err: %s", err.Error())
+	}
+	if n != int64(len(many)) {
+		t.Errorf("The incorrect number of documents are updated\nExpected: %v\nActual: %v", len(many), n)
+	}
+
+	docs, err := datastore.QueryDocuments(adminAuth, confDBName, colName, filters, internal.ListParams{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range docs.Results {
+		got := dec(v)
+		if !got.Done {
+			t.Errorf("The '%s' task is not updated; It should be completed (done=true)", got.Title)
+		}
+	}
+}
+
 func TestIncrementValue(t *testing.T) {
 	task1 := newTask("incr", false)
 	m, err := datastore.CreateDocument(adminAuth, confDBName, colName, task1)

--- a/database/postgresql/base.go
+++ b/database/postgresql/base.go
@@ -250,6 +250,31 @@ func (pg *PostgreSQL) UpdateDocument(auth internal.Auth, dbName, col, id string,
 	return updated, nil
 }
 
+func (pg *PostgreSQL) UpdateDocuments(auth internal.Auth, dbName, col string, filters map[string]interface{}, updateFields map[string]interface{}) (n int64, err error) {
+	where := secureWrite(auth, col)
+	where = applyFilter(where, filters)
+
+	qry := fmt.Sprintf(`
+		UPDATE %s.%s SET
+			data = data || $3
+		%s
+	`, dbName, internal.CleanCollectionName(col), where)
+
+	b, err := json.Marshal(updateFields)
+	if err != nil {
+		return 0, err
+	}
+	res, err := pg.DB.Exec(qry, auth.AccountID, auth.UserID, b)
+	if err != nil {
+		return 0, err
+	}
+	n, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return
+}
+
 func (pg *PostgreSQL) IncrementValue(auth internal.Auth, dbName, col, id, field string, n int) error {
 	where := secureWrite(auth, col)
 

--- a/database/postgresql/base_test.go
+++ b/database/postgresql/base_test.go
@@ -208,6 +208,46 @@ func TestUpdateDocument(t *testing.T) {
 	}
 }
 
+func TestUpdateDocuments(t *testing.T) {
+	task1 := newTask("should be completed", false)
+	task2 := newTask("should be completed", false)
+
+	var many []interface{}
+	many = append(many, task1)
+	many = append(many, task2)
+
+	if err := datastore.BulkCreateDocument(adminAuth, confDBName, colName, many); err != nil {
+		t.Fatal(err)
+	}
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "should be completed"})
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updateFields := map[string]any{"done": true}
+	n, err := datastore.UpdateDocuments(adminAuth, confDBName, colName, filters, updateFields)
+	if err != nil {
+		t.Errorf("The documents are not updated because of an error\nExpected err = nil\nActual err: %s", err.Error())
+	}
+	if n != int64(len(many)) {
+		t.Errorf("The incorrect number of documents are updated\nExpected: %v\nActual: %v", len(many), n)
+	}
+
+	docs, err := datastore.QueryDocuments(adminAuth, confDBName, colName, filters, internal.ListParams{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range docs.Results {
+		got := dec(v)
+		if !got.Done {
+			t.Errorf("The '%s' task is not updated; It should be completed (done=true)", got.Title)
+		}
+	}
+}
+
 func TestIncrementValue(t *testing.T) {
 	task1 := newTask("incr", false)
 	m, err := datastore.CreateDocument(adminAuth, confDBName, colName, task1)

--- a/internal/persister.go
+++ b/internal/persister.go
@@ -49,6 +49,7 @@ type Persister interface {
 	QueryDocuments(auth Auth, dbName, col string, filter map[string]interface{}, params ListParams) (PagedResult, error)
 	GetDocumentByID(auth Auth, dbName, col, id string) (map[string]interface{}, error)
 	UpdateDocument(auth Auth, dbName, col, id string, doc map[string]interface{}) (map[string]interface{}, error)
+	UpdateDocuments(auth Auth, dbName, col string, filters map[string]interface{}, updateFields map[string]interface{}) (int64, error)
 	IncrementValue(auth Auth, dbName, col, id, field string, n int) error
 	DeleteDocument(auth Auth, dbName, col, id string) (int64, error)
 	ListCollections(dbName string) ([]string, error)


### PR DESCRIPTION
Added endpoint for bulk document update #27 

**Purpose:**
The endpoint updates all documents in DB which matches the passed criteria

**HTTP request:**
`PUT /db/{repository-name}/bulk`

**Body schema**
``` 
{
   "update":{field: value},
   "clauses":[
      [field, op, value],
   ]
}
```
**Returns:**
number of edited documents