### PR TITLE
fix error when requesting data from not existing table

### DIFF
--- a/database/memory/base.go
+++ b/database/memory/base.go
@@ -48,6 +48,9 @@ func (m *Memory) BulkCreateDocument(auth internal.Auth, dbName, col string, docs
 func (m *Memory) ListDocuments(auth internal.Auth, dbName, col string, params internal.ListParams) (result internal.PagedResult, err error) {
 	list, err := all[map[string]any](m, dbName, col)
 	if err != nil {
+		if errors.Is(err, collectionNotFoundErr) {
+			return internal.PagedResult{Page: params.Page, Size: params.Size}, nil
+		}
 		return
 	}
 
@@ -77,6 +80,9 @@ func (m *Memory) ListDocuments(auth internal.Auth, dbName, col string, params in
 func (m *Memory) QueryDocuments(auth internal.Auth, dbName, col string, filter map[string]any, params internal.ListParams) (result internal.PagedResult, err error) {
 	list, err := all[map[string]any](m, dbName, col)
 	if err != nil {
+		if errors.Is(err, collectionNotFoundErr) {
+			return internal.PagedResult{Page: params.Page, Size: params.Size}, nil
+		}
 		return
 	}
 

--- a/database/memory/base_test.go
+++ b/database/memory/base_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -303,5 +304,35 @@ func TestListCollections(t *testing.T) {
 	} else if len(results) < 3 {
 		t.Log(results)
 		t.Errorf("expected to have at least one collection got %d", len(results))
+	}
+}
+
+func TestListDocumentsWithNonExistingDB(t *testing.T) {
+	lp := internal.ListParams{Page: 1, Size: 25}
+	expected := internal.PagedResult{Page: 1, Size: 25}
+	result, err := datastore.ListDocuments(adminAuth, "random_name", colName, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result but got %v", result)
+	}
+}
+
+func TestQueryDocumentsWithNonExistingDB(t *testing.T) {
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "where1"})
+
+	lp := internal.ListParams{Page: 1, Size: 5}
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := internal.PagedResult{Page: 1, Size: 5}
+	result, err := datastore.QueryDocuments(adminAuth, "random_name", colName, filters, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result but got %v", result)
 	}
 }

--- a/database/memory/memory.go
+++ b/database/memory/memory.go
@@ -19,6 +19,8 @@ import (
 	FieldOwnerID   = "ownerId"
 )*/
 
+var collectionNotFoundErr = errors.New("collection not found")
+
 func init() {
 	gob.Register(map[string]any{})
 	gob.Register([]any{})
@@ -89,7 +91,7 @@ func getByID[T any](m *Memory, dbName, col, id string, v T) error {
 
 	repo, ok := m.DB[key]
 	if !ok {
-		return errors.New("collection not found")
+		return collectionNotFoundErr
 	}
 
 	b, ok := repo[id]
@@ -106,7 +108,7 @@ func all[T any](m *Memory, dbName, col string) (list []T, err error) {
 
 	repo, ok := m.DB[key]
 	if !ok {
-		return nil, errors.New("collection not found")
+		return nil, collectionNotFoundErr
 	}
 
 	for _, v := range repo {

--- a/database/mongo/base.go
+++ b/database/mongo/base.go
@@ -164,6 +164,9 @@ func (mg *Mongo) ListDocuments(auth internal.Auth, dbName, col string, params in
 	if err != nil {
 		return result, err
 	}
+	if count == 0 {
+		return result, nil
+	}
 
 	result.Total = count
 
@@ -232,6 +235,9 @@ func (mg *Mongo) QueryDocuments(auth internal.Auth, dbName, col string, filter m
 	count, err := db.Collection(internal.CleanCollectionName(col)).CountDocuments(mg.Ctx, filter)
 	if err != nil {
 		return result, err
+	}
+	if count == 0 {
+		return result, nil
 	}
 
 	result.Total = count

--- a/database/mongo/base_test.go
+++ b/database/mongo/base_test.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -303,5 +304,35 @@ func TestListCollections(t *testing.T) {
 	} else if len(results) < 3 {
 		t.Log(results)
 		t.Errorf("expected to have at least one collection got %d", len(results))
+	}
+}
+
+func TestListDocumentsWithNonExistingDB(t *testing.T) {
+	lp := internal.ListParams{Page: 1, Size: 25}
+	expected := internal.PagedResult{Page: 1, Size: 25}
+	result, err := datastore.ListDocuments(adminAuth, "random_name", colName, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result but got %v", result)
+	}
+}
+
+func TestQueryDocumentsWithNonExistingDB(t *testing.T) {
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "where1"})
+
+	lp := internal.ListParams{Page: 1, Size: 5}
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := internal.PagedResult{Page: 1, Size: 5}
+	result, err := datastore.QueryDocuments(adminAuth, "random_name", colName, filters, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result\nActual: %#v\nExpected: %#v", result, expected)
 	}
 }

--- a/database/postgresql/base_test.go
+++ b/database/postgresql/base_test.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -303,5 +304,35 @@ func TestListCollections(t *testing.T) {
 	} else if len(results) < 6 {
 		t.Log(results)
 		t.Errorf("expected to have at least one collection got %d", len(results))
+	}
+}
+
+func TestListDocumentsWithNonExistingDB(t *testing.T) {
+	lp := internal.ListParams{Page: 1, Size: 25}
+	expected := internal.PagedResult{Page: 1, Size: 25}
+	result, err := datastore.ListDocuments(adminAuth, "random_name", colName, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result but got %v", result)
+	}
+}
+
+func TestQueryDocumentsWithNonExistingDB(t *testing.T) {
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"title", "=", "where1"})
+
+	lp := internal.ListParams{Page: 1, Size: 5}
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := internal.PagedResult{Page: 1, Size: 5}
+	result, err := datastore.QueryDocuments(adminAuth, "random_name", colName, filters, lp)
+	if err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("expected empty result but got %v", result)
 	}
 }


### PR DESCRIPTION
Fixed #46 

Added error handling for the case when the table does not exist for list/query cases. 