### PR TITLE
Expose an HTTP client to the function runtime

### DIFF
--- a/function/helpers.go
+++ b/function/helpers.go
@@ -1,0 +1,39 @@
+package function
+
+type JSFetchOptionsArg struct {
+	Method         string
+	Headers        map[string]string
+	Body           string
+	Mode           string
+	Credentials    string
+	Cache          string
+	Redirect       string
+	Referrer       string
+	ReferrerPolicy string
+	Integrity      string
+	Keepalive      string
+	Signal         string
+}
+
+type HTTPResponse struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+
+func NewJSFetcthOptionArg() JSFetchOptionsArg {
+	defaultOptions := JSFetchOptionsArg{
+		Method:         "GET",
+		Headers:        make(map[string]string, 0),
+		Body:           "",
+		Mode:           "no-cors",
+		Credentials:    "omit",
+		Cache:          "no-cache",
+		Redirect:       "error",
+		Referrer:       "",
+		ReferrerPolicy: "",
+		Integrity:      "",
+		Keepalive:      "",
+		Signal:         "",
+	}
+	return defaultOptions
+}

--- a/functions_test.go
+++ b/functions_test.go
@@ -72,7 +72,71 @@ func TestFunctionsExecuteDBOperations(t *testing.T) {
 			log("query doc id: " + qres.content.results[0].id);
 			return;
 		}
-		
+
+		var getRes = fetch("https://run.mocky.io/v3/427873c5-4baa-4f68-b880-b6e3e45b3d4d");
+		if (!getRes.ok) {
+			log("ERROR: sending GET request");
+			log(getRes.content);
+			return;
+		}
+
+		var postRes = fetch("https://run.mocky.io/v3/427873c5-4baa-4f68-b880-b6e3e45b3d4d", {
+			method: "POST",
+			headers: {
+				"Content-Type" : "application/json"
+			}, 
+			body: {
+				"test": "test msg"
+			}
+		});
+		if (!postRes.ok) {
+			log("ERROR: sending POST request");
+			log(postRes.content);
+			return;
+		}
+
+		var putRes = fetch("https://run.mocky.io/v3/427873c5-4baa-4f68-b880-b6e3e45b3d4d", {
+			method: "PUT",
+			headers: {
+				"Content-Type" : "application/json"
+			}, 
+			body: {
+				"test": "test msg"
+			}
+		});
+		if (!putRes.ok) {
+			log("ERROR: sending PUT request");
+			log(putRes.content);
+			return;
+		}
+		var patchRes = fetch("https://run.mocky.io/v3/427873c5-4baa-4f68-b880-b6e3e45b3d4d", {
+			method: "PATCH",
+			headers: {
+				"Content-Type" : "application/json"
+			}, 
+			body: {
+				"test": "test msg"
+			}
+		});
+		if (!patchRes.ok) {
+			log("ERROR: sending PATCH request");
+			log(patchRes.content);
+			return;
+		}
+		var delRes = fetch("https://run.mocky.io/v3/427873c5-4baa-4f68-b880-b6e3e45b3d4d", {
+			method: "DELETE",
+			headers: {
+				"Content-Type" : "application/json"
+			}, 
+			body: {
+				"test": "test msg"
+			}
+		});
+		if (!delRes.ok) {
+			log("ERROR: sending DELETE request");
+			log(delRes.content);
+			return;
+		}
 	}`
 	data := internal.ExecData{
 		FunctionName: "unittest",


### PR DESCRIPTION
Add a function runtime helper complaint with fetchAPI

Currently, the SB doesn’t have a way to call HTTP/S endpoints from the SB’s function.This PR adds a helper called “fetch”, which is compliant with JS Fetch API. The current implementation supports only GET, PUT, POST, PATCH, and DELETE. It can be extendedfurther.

Fixes #43