### PR TITLE
chore: add local cache sub/pub events

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -148,13 +148,13 @@ func (c *Cache) Publish(msg internal.Command) error {
 func (c *Cache) PublishDocument(channel, typ string, v interface{}) {
 	subs, err := c.Rdb.PubSubNumSub(c.Ctx, channel).Result()
 	if err != nil {
-		c.log.Error().Err(err).Msgf("error getting db subscribers for ", channel)
+		c.log.Error().Err(err).Msgf("error getting db subscribers for %s", channel)
 		return
 	}
 
 	count, ok := subs[channel]
 	if !ok {
-		c.log.Warn().Msgf("cannot find channel in subs: %d", channel)
+		c.log.Warn().Msgf("cannot find channel in subs: %s", channel)
 		return
 	} else if count == 0 {
 		return

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,216 @@
+package cache
+
+import (
+	"encoding/json"
+	"github.com/staticbackendhq/core/config"
+	"github.com/staticbackendhq/core/internal"
+	"github.com/staticbackendhq/core/logger"
+	"os"
+	"testing"
+	"time"
+)
+
+var (
+	redisCache *Cache
+	devCache   *CacheDev
+	adminToken internal.Token
+	adminAuth  internal.Auth
+	document   string
+)
+
+type suite struct {
+	name  string
+	cache internal.Volatilizer
+}
+
+func TestMain(m *testing.M) {
+	config.Current = config.LoadConfig()
+	logz := logger.Get(config.Current)
+	redisCache = NewCache(logz)
+	devCache = NewDevCache(logz)
+
+	adminAuth = internal.Auth{
+		AccountID: "047cfe5b-b91d-4ec6-9bc2-8f68309d8532",
+		UserID:    "5dc37900-2a2e-46d9-8a5d-6699376975ad",
+		Email:     "test@email.com",
+		Role:      100,
+		Token:     adminToken.Token,
+	}
+	document = `{"accountId":"047cfe5b-b91d-4ec6-9bc2-8f68309d8532","created":"2022-08-31T19:07:36.296787226+03:00","done":true,"id":"872c8192-c610-4fc5-bc8e-22c01f01c798","likes":0,"title":"updated","todos":[{"done":true,"title":"updated"},{"done":false,"title":"sub2"}]}`
+	os.Exit(m.Run())
+}
+
+func TestCacheSubscribe(t *testing.T) {
+	tests := []suite{
+		{name: "subscribe with redis cache", cache: redisCache},
+		{name: "subscribe with dev mem cache", cache: devCache},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver := make(chan internal.Command)
+			closeCn := make(chan bool)
+			defer close(receiver)
+			defer close(closeCn)
+
+			payload := internal.Command{Type: internal.MsgTypeError, Data: "invalid token", Channel: "random_cahn"}
+
+			go tc.cache.Subscribe(receiver, "", payload.Channel, closeCn)
+			time.Sleep(10 * time.Millisecond) // need to wait for proper subscriber startup
+
+			err := tc.cache.Publish(payload)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			timer := time.NewTimer(5 * time.Second)
+			select {
+			case res := <-receiver:
+				if res != payload {
+					t.Error("Incorrect message is received")
+				}
+				break
+			case <-timer.C:
+				t.Fatal("The channel does not received a message")
+
+			}
+			closeCn <- true
+		})
+	}
+}
+
+func TestCacheSubscribeOnDBEvent(t *testing.T) {
+	tests := []suite{
+		{name: "receive db event with redis cache", cache: redisCache},
+		{name: "receive db event with dev mem cache", cache: devCache},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver := make(chan internal.Command)
+			closeCn := make(chan bool)
+			defer close(receiver)
+			defer close(closeCn)
+
+			err := tc.cache.SetTyped("token", adminAuth)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			payload := internal.Command{Type: internal.MsgTypeDBUpdated, Data: document, Channel: "random_cahn"}
+
+			go tc.cache.Subscribe(receiver, "token", payload.Channel, closeCn)
+
+			time.Sleep(10 * time.Millisecond) // need to wait for proper subscriber startup
+
+			err = tc.cache.Publish(payload)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			timer := time.NewTimer(5 * time.Second)
+			defer timer.Stop()
+			select {
+			case res := <-receiver:
+				if res != payload {
+					t.Error("Incorrect message is received")
+				}
+				break
+			case <-timer.C:
+				t.Fatal("The channel does not received a message")
+
+			}
+			closeCn <- true
+		})
+	}
+}
+
+func TestCacheDontReceiveDBEvent(t *testing.T) {
+	tests := []suite{
+		{
+			name:  "DB event with incorrect token is not send to subscriber with redis cache",
+			cache: redisCache,
+		},
+		{
+			name:  "DB event with incorrect token is not send to subscriber with dev cache",
+			cache: devCache,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver := make(chan internal.Command)
+			closeCn := make(chan bool)
+			defer close(receiver)
+			defer close(closeCn)
+
+			wrongAuth := adminAuth
+			wrongAuth.AccountID = "wrongId"
+			err := tc.cache.SetTyped("token", wrongAuth)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			event := internal.Command{Type: internal.MsgTypeDBUpdated, Data: document, Channel: "chan"}
+			go tc.cache.Subscribe(receiver, "token", event.Channel, closeCn)
+
+			time.Sleep(10 * time.Millisecond) // need to wait for proper subscriber startup
+
+			err = tc.cache.Publish(event)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			timer := time.NewTimer(2 * time.Second)
+			defer timer.Stop()
+			select {
+			case res := <-receiver:
+				closeCn <- true
+				t.Fatalf("The message should not be received\nReceived: %#v", res)
+			case <-timer.C:
+				closeCn <- true
+
+			}
+		})
+	}
+}
+
+func TestCachePublishDocument(t *testing.T) {
+	tests := []suite{
+		{name: "receive db event with redis cache", cache: redisCache},
+		{name: "receive db event with dev mem cache", cache: devCache},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			receiver := make(chan internal.Command)
+			closeCn := make(chan bool)
+			defer close(receiver)
+			defer close(closeCn)
+
+			err := tc.cache.SetTyped("token", adminAuth)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			payload := internal.Command{Type: internal.MsgTypeDBUpdated, Data: document, Channel: "random_cahn"}
+
+			// convert to map for simulation of real usage
+			var documentMap map[string]interface{}
+			if err := json.Unmarshal([]byte(document), &documentMap); err != nil {
+				t.Fatal(err.Error())
+			}
+
+			go tc.cache.Subscribe(receiver, "token", payload.Channel, closeCn)
+
+			time.Sleep(10 * time.Millisecond) // need to wait for proper subscriber startup
+
+			tc.cache.PublishDocument(payload.Channel, payload.Type, documentMap)
+			timer := time.NewTimer(5 * time.Second)
+			defer timer.Stop()
+			select {
+			case res := <-receiver:
+				if res != payload {
+					t.Error("Incorrect message is received")
+				}
+				break
+			case <-timer.C:
+				t.Fatal("The channel does not received a message")
+
+			}
+			closeCn <- true
+		})
+	}
+}

--- a/cache/dev.go
+++ b/cache/dev.go
@@ -3,17 +3,26 @@ package cache
 import (
 	"encoding/json"
 	"errors"
-
+	"fmt"
+	"github.com/staticbackendhq/core/cache/observer"
 	"github.com/staticbackendhq/core/internal"
+	"github.com/staticbackendhq/core/logger"
 )
 
 type CacheDev struct {
-	data map[string]string
+	data     map[string]string
+	log      *logger.Logger
+	observer observer.Observer
 }
 
-func NewDevCache() *CacheDev {
-	return &CacheDev{data: make(map[string]string)}
+func NewDevCache(log *logger.Logger) *CacheDev {
+	return &CacheDev{
+		data:     make(map[string]string),
+		observer: observer.NewObserver(log),
+		log:      log,
+	}
 }
+
 func (d *CacheDev) Get(key string) (val string, err error) {
 	val, ok := d.data[key]
 	if !ok {
@@ -61,15 +70,119 @@ func (d *CacheDev) Dec(key string, by int64) (int64, error) {
 }
 
 func (d *CacheDev) Subscribe(send chan internal.Command, token, channel string, close chan bool) {
-	//TODO: implement this
+	pubsub := d.observer.Subscribe(channel)
+
+	ch := pubsub.Channel()
+
+	for {
+		select {
+		case m := <-ch:
+			var msg internal.Command
+			if err := json.Unmarshal([]byte(m.(string)), &msg); err != nil {
+				d.log.Error().Err(err).Msg("error parsing JSON message")
+				_ = pubsub.Close()
+				_ = d.observer.Unsubscribe(channel, pubsub)
+				return
+			}
+
+			// TODO: this will need more thinking
+			if msg.Type == internal.MsgTypeChanIn {
+				msg.Type = internal.MsgTypeChanOut
+			} else if msg.IsSystemEvent {
+
+			} else if msg.IsDBEvent() && d.HasPermission(token, channel, msg.Data) == false {
+				continue
+			}
+			send <- msg
+		case <-close:
+			_ = pubsub.Close()
+			_ = d.observer.Unsubscribe(channel, pubsub)
+			return
+		}
+	}
 }
 
 func (d *CacheDev) Publish(msg internal.Command) error {
-	return errors.New("not implemented")
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	// Publish the event to system so server-side function can trigger
+	go func(sysmsg internal.Command) {
+		sysmsg.IsSystemEvent = true
+		b, err := json.Marshal(sysmsg)
+		if err != nil {
+			d.log.Error().Err(err).Msg("error marshaling the system msg")
+			return
+		}
+		if err := d.observer.Publish("sbsys", string(b)); err != nil {
+			d.log.Error().Err(err).Msg("error occurred during publishing to 'sbsys' channel")
+		}
+	}(msg)
+
+	return d.observer.Publish(msg.Channel, string(b))
 }
 
 func (d *CacheDev) PublishDocument(channel, typ string, v any) {
-	//TODO: Implement this
+	subs := d.observer.PubNumSub(channel)
+
+	count, ok := subs[channel]
+	if !ok {
+		d.log.Warn().Msgf("cannot find channel in subs: %s", channel)
+		return
+	} else if count == 0 {
+		return
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		d.log.Error().Err(err).Msg("error publishing db doc")
+		return
+	}
+
+	msg := internal.Command{
+		Channel: channel,
+		Data:    string(b),
+		Type:    typ,
+	}
+
+	if err := d.Publish(msg); err != nil {
+		d.log.Error().Err(err).Msg("unable to publish db doc events")
+	}
+}
+
+func (d *CacheDev) HasPermission(token, repo, payload string) bool {
+	var me internal.Auth
+	if err := d.GetTyped(token, &me); err != nil {
+		return false
+	}
+
+	docs := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(payload), &docs); err != nil {
+		d.log.Error().Err(err).Msg("error decoding docs for permissions check")
+
+		return false
+	}
+
+	switch internal.ReadPermission(repo) {
+	case internal.PermGroup:
+		acctID, ok := docs["accountId"]
+		if !ok {
+			return false
+		}
+
+		return fmt.Sprintf("%v", acctID) == me.AccountID
+	case internal.PermOwner:
+		owner, ok := docs["ownerId"]
+		if !ok {
+			return false
+		}
+
+		return fmt.Sprintf("%v", owner) == me.UserID
+	default:
+		return true
+	}
 }
 
 func (d *CacheDev) QueueWork(key, value string) error {

--- a/cache/observer/observer.go
+++ b/cache/observer/observer.go
@@ -1,0 +1,114 @@
+package observer
+
+import (
+	"errors"
+	"github.com/staticbackendhq/core/logger"
+	"sync"
+	"time"
+)
+
+type Observer interface {
+	Subscribe(channel string) Subscriber
+	Publish(channel string, msg interface{}) error
+	Unsubscribe(channel string, subscriber Subscriber) error
+	PubNumSub(channel string) map[string]int
+}
+
+type Subscriber interface {
+	Channel() <-chan interface{}
+	Close() error
+}
+
+type memSubscriber struct {
+	closed bool
+	msgCh  chan interface{}
+}
+
+func NewSubscriber() *memSubscriber {
+	ch := make(chan interface{})
+	sub := &memSubscriber{closed: false, msgCh: ch}
+	return sub
+}
+
+func (ps *memSubscriber) Channel() <-chan interface{} {
+	return ps.msgCh
+}
+
+func (ps *memSubscriber) Close() error {
+	if ps.closed {
+		return errors.New("channel is already closed")
+	}
+	close(ps.msgCh)
+	ps.closed = true
+	return nil
+}
+
+type memObserver struct {
+	Subscriptions map[string][]*memSubscriber
+	mx            sync.Mutex
+	log           *logger.Logger
+}
+
+func NewObserver(log *logger.Logger) Observer {
+	subs := make(map[string][]*memSubscriber)
+	return &memObserver{Subscriptions: subs, mx: sync.Mutex{}, log: log}
+}
+
+func (o *memObserver) Subscribe(channel string) Subscriber {
+	o.mx.Lock()
+	defer o.mx.Unlock()
+
+	newSub := NewSubscriber()
+	if subs, ok := o.Subscriptions[channel]; ok {
+		o.Subscriptions[channel] = append(subs, newSub)
+	} else if !ok {
+		o.Subscriptions[channel] = append([]*memSubscriber{}, newSub)
+	}
+	return newSub
+}
+
+func (o *memObserver) Publish(channel string, msg interface{}) error {
+	o.mx.Lock()
+	defer o.mx.Unlock()
+	if len(o.Subscriptions[channel]) == 0 {
+		return errors.New("not subscribers for chan: " + channel)
+	}
+	for _, sub := range o.Subscriptions[channel] {
+		sub := sub
+
+		go func() {
+			timer := time.NewTimer(15 * time.Second)
+			select {
+			case sub.msgCh <- msg:
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
+				o.log.Error().Msg("the previous message is not read; dropping this message")
+				timer.Stop()
+			}
+		}()
+
+	}
+	return nil
+}
+
+func (o *memObserver) Unsubscribe(channel string, subscriber Subscriber) error {
+	o.mx.Lock()
+	defer o.mx.Unlock()
+	for k, v := range o.Subscriptions[channel] {
+		if v == subscriber {
+			o.Subscriptions[channel] = append(o.Subscriptions[channel][:k], o.Subscriptions[channel][k+1:]...)
+			return nil
+		}
+	}
+	return errors.New("given subscriber is already unsubscribed")
+}
+
+func (o *memObserver) PubNumSub(channel string) map[string]int {
+	res := make(map[string]int)
+	o.mx.Lock()
+	defer o.mx.Unlock()
+	res[channel] = len(o.Subscriptions[channel])
+	return res
+}

--- a/server.go
+++ b/server.go
@@ -289,7 +289,7 @@ func Start(c config.AppConfig, log *logger.Logger) {
 func initServices(dbHost string, log *logger.Logger) {
 
 	if strings.EqualFold(dbHost, "mem") {
-		volatile = cache.NewDevCache()
+		volatile = cache.NewDevCache(log)
 	} else {
 		volatile = cache.NewCache(log)
 	}


### PR DESCRIPTION
Add a local observer for the Pub/sub cache events #42 

`Observer` provides a possibility to subscribe to a specific event and publish a message for all subscribers of the channel.
The `memObserver` struct contains a map with a slice of subscribers where the key of the map is a specific channel.

The `subscriber` is basically a wrapper for the channel that is listening for the changes
