### PR TITLE
Add cache events in bulk update func

### DIFF
--- a/database/memory/base.go
+++ b/database/memory/base.go
@@ -117,6 +117,20 @@ func (m *Memory) GetDocumentByID(auth model.Auth, dbName, col, id string) (doc m
 	return
 }
 
+func (m *Memory) GetDocumentsByIDs(auth model.Auth, dbName, col string, ids []string) (docs []map[string]interface{}, err error) {
+
+	for _, id := range ids {
+		var doc map[string]interface{}
+		if err := getByID(m, dbName, col, id, &doc); err != nil {
+			return []map[string]interface{}{}, err
+		}
+		docs = append(docs, doc)
+	}
+
+	docs = secureRead(auth, col, docs)
+	return docs, nil
+}
+
 func (m *Memory) UpdateDocument(auth model.Auth, dbName, col, id string, doc map[string]any) (exists map[string]any, err error) {
 	exists, err = m.GetDocumentByID(auth, dbName, col, id)
 	if err != nil {

--- a/database/memory/base_test.go
+++ b/database/memory/base_test.go
@@ -169,6 +169,40 @@ func TestGetDocumentByID(t *testing.T) {
 	}
 }
 
+func TestGetDocumentsByIDs(t *testing.T) {
+	input := []map[string]interface{}{newTask("getbyids123", false), newTask("getbyids123", false)}
+
+	var assertionTasks []map[string]interface{}
+	var ids []string
+
+	for _, v := range input {
+		res, err := datastore.CreateDocument(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, res["id"].(string))
+	}
+
+	for _, v := range ids {
+		m, err := datastore.GetDocumentByID(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertionTasks = append(assertionTasks, m)
+	}
+
+	res, err := datastore.GetDocumentsByIDs(adminAuth, confDBName, colName, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(assertionTasks) != len(res) {
+		t.Fatal("received incorrect number of documents")
+	}
+	if !reflect.DeepEqual(assertionTasks, res) {
+		t.Errorf("Does not received expected tasks\nE: %v\nA: %v", assertionTasks, res)
+	}
+}
+
 func TestUpdateDocument(t *testing.T) {
 	task1 := newTask("inserted", false)
 

--- a/database/mongo/base_test.go
+++ b/database/mongo/base_test.go
@@ -169,6 +169,40 @@ func TestGetDocumentByID(t *testing.T) {
 	}
 }
 
+func TestGetDocumentsByIDs(t *testing.T) {
+	input := []map[string]interface{}{newTask("getbyids1", false), newTask("getbyids1", false)}
+
+	var assertionTasks []map[string]interface{}
+	var ids []string
+
+	for _, v := range input {
+		res, err := datastore.CreateDocument(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, res["id"].(string))
+	}
+
+	for _, v := range ids {
+		m, err := datastore.GetDocumentByID(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertionTasks = append(assertionTasks, m)
+	}
+
+	res, err := datastore.GetDocumentsByIDs(adminAuth, confDBName, colName, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(assertionTasks) != len(res) {
+		t.Fatal("received incorrect number of documents")
+	}
+	if !reflect.DeepEqual(assertionTasks, res) {
+		t.Errorf("Does not received expected tasks\nE: %v\nA: %v", assertionTasks, res)
+	}
+}
+
 func TestUpdateDocument(t *testing.T) {
 	task1 := newTask("inserted", false)
 

--- a/database/mongo/mongo_test.go
+++ b/database/mongo/mongo_test.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"context"
 	"errors"
+	"github.com/staticbackendhq/core/logger"
 	"log"
 	"os"
 	"testing"
@@ -51,6 +52,7 @@ func TestMain(m *testing.M) {
 		Client:          cl,
 		Ctx:             context.Background(),
 		PublishDocument: fakePubDocEvent,
+		log:             logger.Get(config.Current),
 	}
 
 	if err := datastore.Ping(); err != nil {

--- a/database/persister.go
+++ b/database/persister.go
@@ -87,6 +87,8 @@ type Persister interface {
 	QueryDocuments(auth model.Auth, dbName, col string, filter map[string]interface{}, params model.ListParams) (model.PagedResult, error)
 	// GetDocumentByID returns a record by its ID
 	GetDocumentByID(auth model.Auth, dbName, col, id string) (map[string]interface{}, error)
+	// GetDocumentsByIDs returns a list of records by multiple ids
+	GetDocumentsByIDs(auth model.Auth, dbName, col string, ids []string) ([]map[string]interface{}, error)
 	// UpdateDocument updates a full or partial record
 	UpdateDocument(auth model.Auth, dbName, col, id string, doc map[string]interface{}) (map[string]interface{}, error)
 	// UpdateDocuments updates multiple records matching filters

--- a/database/postgresql/base_test.go
+++ b/database/postgresql/base_test.go
@@ -209,6 +209,40 @@ func TestUpdateDocument(t *testing.T) {
 	}
 }
 
+func TestGetDocumentsByIDs(t *testing.T) {
+	input := []map[string]interface{}{newTask("getbyids1", false), newTask("getbyids1", false)}
+
+	var assertionTasks []map[string]interface{}
+	var ids []string
+
+	for _, v := range input {
+		res, err := datastore.CreateDocument(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, res["id"].(string))
+	}
+
+	for _, v := range ids {
+		m, err := datastore.GetDocumentByID(adminAuth, confDBName, colName, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertionTasks = append(assertionTasks, m)
+	}
+
+	res, err := datastore.GetDocumentsByIDs(adminAuth, confDBName, colName, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(assertionTasks) != len(res) {
+		t.Fatal("received incorrect number of documents")
+	}
+	if !reflect.DeepEqual(assertionTasks, res) {
+		t.Errorf("Does not received expected tasks\nE: %v\nA: %v", assertionTasks, res)
+	}
+}
+
 func TestUpdateDocuments(t *testing.T) {
 	task1 := newTask("should be completed", false)
 	task2 := newTask("should be completed", false)

--- a/db.go
+++ b/db.go
@@ -217,16 +217,12 @@ func (database *Database) getByIds(w http.ResponseWriter, r *http.Request) {
 	_, r.URL.Path = ShiftPath(r.URL.Path)
 	col, r.URL.Path = ShiftPath(r.URL.Path)
 
-	var body map[string][]string
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	var ids []string
+	if err := parseBody(r.Body, &ids); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	ids, ok := body["ids"]
-	if !ok {
-		http.Error(w, "ids should be provided", http.StatusBadRequest)
-		return
-	}
+
 	if len(ids) < 1 {
 		http.Error(w, "ids list can not be empty", http.StatusBadRequest)
 		return

--- a/db.go
+++ b/db.go
@@ -23,6 +23,8 @@ func (database *Database) dbreq(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		if len(r.URL.Query().Get("bulk")) > 0 {
 			database.bulkAdd(w, r)
+		} else if r.URL.Query().Has("ids") {
+			database.getByIds(w, r)
 		} else {
 			database.add(w, r)
 		}
@@ -195,6 +197,42 @@ func (database *Database) query(w http.ResponseWriter, r *http.Request) {
 	col, r.URL.Path = ShiftPath(r.URL.Path)
 
 	result, err := backend.DB.QueryDocuments(auth, conf.Name, col, filter, params)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respond(w, http.StatusOK, result)
+}
+
+func (database *Database) getByIds(w http.ResponseWriter, r *http.Request) {
+	conf, auth, err := middleware.Extract(r, true)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	col := ""
+
+	_, r.URL.Path = ShiftPath(r.URL.Path)
+	col, r.URL.Path = ShiftPath(r.URL.Path)
+
+	var body map[string][]string
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	ids, ok := body["ids"]
+	if !ok {
+		http.Error(w, "ids should be provided", http.StatusBadRequest)
+		return
+	}
+	if len(ids) < 1 {
+		http.Error(w, "ids list can not be empty", http.StatusBadRequest)
+		return
+	}
+
+	result, err := backend.DB.GetDocumentsByIDs(auth, conf.Name, col, ids)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/db_test.go
+++ b/db_test.go
@@ -260,9 +260,7 @@ func TestDBBulkUpdate(t *testing.T) {
 }
 
 func TestDBGetByIds(t *testing.T) {
-	var data = new(struct {
-		Ids []string `json:"ids"`
-	})
+	var data []string
 
 	tasks := []Task{
 		{
@@ -289,7 +287,7 @@ func TestDBGetByIds(t *testing.T) {
 		if err := parseBody(resp.Body, &saved); err != nil {
 			t.Fatal(err)
 		}
-		data.Ids = append(data.Ids, saved.ID)
+		data = append(data, saved.ID)
 		createdTasks = append(createdTasks, saved)
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -259,6 +259,56 @@ func TestDBBulkUpdate(t *testing.T) {
 	}
 }
 
+func TestDBGetByIds(t *testing.T) {
+	var data = new(struct {
+		Ids []string `json:"ids"`
+	})
+
+	tasks := []Task{
+		{
+			Title: "should be returned 1",
+			Done:  false,
+		},
+		{
+			Title: "should be returned 2",
+			Done:  false,
+		},
+	}
+
+	var createdTasks []Task
+
+	for _, v := range tasks {
+		resp := dbReq(t, db.add, "POST", "/db/tasks", v)
+		defer resp.Body.Close()
+
+		if resp.StatusCode > 299 {
+			t.Fatal(GetResponseBody(t, resp))
+		}
+
+		var saved Task
+		if err := parseBody(resp.Body, &saved); err != nil {
+			t.Fatal(err)
+		}
+		data.Ids = append(data.Ids, saved.ID)
+		createdTasks = append(createdTasks, saved)
+	}
+
+	resp := dbReq(t, db.getByIds, "POST", "/db/tasks?byids=1", data)
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 299 {
+		t.Fatal(GetResponseBody(t, resp))
+	}
+
+	var result []Task
+	if err := parseBody(resp.Body, &result); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(createdTasks, result) {
+		t.Errorf("Received incorrect data\nexpected: %v\ngot: %v", createdTasks, result)
+	}
+}
+
 func TestDBIncrease(t *testing.T) {
 	task :=
 		Task{


### PR DESCRIPTION
Added endpoint for getting several records by ids list as described in #53 

```
URL example: /db/tasks?byids=1
body: ['id1-here', 'id2-here', '...']
```

Also added the cache events in bulk update functions
Closes #53 