### PR TITLE
fix(storage/upload): change arguments in ext to avoid error in ui

### DIFF
--- a/backend/file.go
+++ b/backend/file.go
@@ -32,7 +32,7 @@ type SavedFile struct {
 // Save saves a file content to the file storage (Storer interface) and to the
 // database
 func (f FileStore) Save(filename, name string, file io.ReadSeeker, size int64) (sf SavedFile, err error) {
-	ext := filepath.Ext(name)
+	ext := filepath.Ext(filename)
 
 	if len(name) == 0 {
 		// if no forced name is used, let's use the original file name


### PR DESCRIPTION
As I know the `name` field is optional and sometimes user won't use it. But in our UI we need to know file ext without `.`
Actually it would be better to use original file name with correct ext instead of using optional field