### PR TITLE
Fix  helpers/RandStringRunes 

### DIFF
--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -11,8 +11,9 @@ var (
 	letterRunes = []rune("abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ2345679")
 )
 
-// RandStringRunes returns a random string with n characters
+// RandStringRunes returns a random string with n characters where n>=1
 func RandStringRunes(n int) string {
+	n = maxInt(1, n)
 	b := make([]rune, n)
 	for i := range b {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
@@ -32,4 +33,12 @@ func CleanUpFileName(s string) string {
 
 	return exp.ReplaceAllString(s, "")
 
+}
+
+// maxInt returns max value between two integers
+func maxInt(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
 }

--- a/internal/helpers_test.go
+++ b/internal/helpers_test.go
@@ -11,6 +11,15 @@ func TestRandStringRunes(t *testing.T) {
 	}
 }
 
+func TestRandStringRuneMinValue(t *testing.T) {
+	lengths := []int{0, -1, -2}
+	for _, length := range lengths {
+		if p := RandStringRunes(length); len(p) != 1 {
+			t.Errorf("%s: expected length %d got %d", p, 1, len(p))
+		}
+	}
+}
+
 func TestCleanUpFileName(t *testing.T) {
 	tables := make(map[string]string)
 	tables["dummy_1_.sample"] = "dummy__"


### PR DESCRIPTION
Limit minimum length of string generated by `RandStringRunes(n)` to 1 . This is avoid panic when  `n `values is less than 1.
Add tests for the same.