### PR TITLE
implemented the bulk delete closing #27

### DIFF
--- a/database/memory/base_test.go
+++ b/database/memory/base_test.go
@@ -331,6 +331,40 @@ func TestDeleteDocument(t *testing.T) {
 	}
 }
 
+func TesDeleteDocuments(t *testing.T) {
+	task1 := newTask("abc123456-bulkdel", true)
+	task2 := newTask("def123456-bulkdel", true)
+
+	var many []interface{}
+	many = append(many, task1)
+	many = append(many, task2)
+
+	if err := datastore.BulkCreateDocument(adminAuth, confDBName, colName, many); err != nil {
+		t.Fatal(err)
+	}
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"done", "=", true})
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := datastore.DeleteDocuments(adminAuth, confDBName, colName, filters)
+	if err != nil {
+		t.Errorf("The documents are not updated because of an error\nExpected err = nil\nActual err: %s", err.Error())
+	} else if n < 2 {
+		t.Errorf("expected deleted documents count to be > 2, got %d", n)
+	}
+
+	docs, err := datastore.QueryDocuments(adminAuth, confDBName, colName, filters, model.ListParams{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatal(err)
+	} else if len(docs.Results) > 0 {
+		t.Errorf("should not have any docs with filter done=true got %d", len(docs.Results))
+	}
+}
+
 func TestListCollections(t *testing.T) {
 	results, err := datastore.ListCollections(confDBName)
 	if err != nil {

--- a/database/mongo/base_test.go
+++ b/database/mongo/base_test.go
@@ -331,6 +331,40 @@ func TestDeleteDocument(t *testing.T) {
 	}
 }
 
+func TesDeleteDocuments(t *testing.T) {
+	task1 := newTask("abc123456-bulkdel", true)
+	task2 := newTask("def123456-bulkdel", true)
+
+	var many []interface{}
+	many = append(many, task1)
+	many = append(many, task2)
+
+	if err := datastore.BulkCreateDocument(adminAuth, confDBName, colName, many); err != nil {
+		t.Fatal(err)
+	}
+	var clauses [][]interface{}
+	clauses = append(clauses, []interface{}{"done", "=", true})
+
+	filters, err := datastore.ParseQuery(clauses)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := datastore.DeleteDocuments(adminAuth, confDBName, colName, filters)
+	if err != nil {
+		t.Errorf("The documents are not updated because of an error\nExpected err = nil\nActual err: %s", err.Error())
+	} else if n < 2 {
+		t.Errorf("expected deleted documents count to be > 2, got %d", n)
+	}
+
+	docs, err := datastore.QueryDocuments(adminAuth, confDBName, colName, filters, model.ListParams{Page: 1, Size: 5})
+	if err != nil {
+		t.Fatal(err)
+	} else if len(docs.Results) > 0 {
+		t.Errorf("should not have any docs with filter done=true got %d", len(docs.Results))
+	}
+}
+
 func TestListCollections(t *testing.T) {
 	results, err := datastore.ListCollections(confDBName)
 	if err != nil {

--- a/database/persister.go
+++ b/database/persister.go
@@ -97,6 +97,7 @@ type Persister interface {
 	IncrementValue(auth model.Auth, dbName, col, id, field string, n int) error
 	// DeleteDocument removes a record by its ID
 	DeleteDocument(auth model.Auth, dbName, col, id string) (int64, error)
+	DeleteDocuments(auth model.Auth, dbName, col string, filters map[string]interface{}) (int64, error)
 	// ListCollections returns all collections for a database
 	ListCollections(dbName string) ([]string, error)
 	// ParseQuery parses the filters into an internal query clauses


### PR DESCRIPTION
This adds a bulk delete functionality similar to the previously implemented bulk update.

The filtering criterias must be pass via the URL query string parameter `x` and must be `base64` encoded.