### PR TITLE
Fixes TestHtmlToPDF occasional issue

### DIFF
--- a/extras.go
+++ b/extras.go
@@ -158,7 +158,7 @@ func (ex *extras) htmlToX(w http.ResponseWriter, r *http.Request) {
 	var buf []byte
 
 	if err := chromedp.Run(ctx, ex.toBytes(data, &buf)); err != nil {
-		http.Error(w, fmt.Sprintf("htmltox chromedp run %s"err.Error()), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/extras.go
+++ b/extras.go
@@ -52,7 +52,7 @@ func (ex *extras) resizeImage(w http.ResponseWriter, r *http.Request) {
 
 	ext := filepath.Ext(h.Filename)
 
-	//TODO: Remove all but a-zA-Z/ from name
+	// TODO: Remove all but a-zA-Z/ from name
 
 	name := r.Form.Get("name")
 	if len(name) == 0 {
@@ -152,14 +152,8 @@ func (ex *extras) htmlToX(w http.ResponseWriter, r *http.Request) {
 		chromedp.Flag("disable-gpu", true),
 	)*/
 
-	// make sure it can timeout
-	cctx, ccancel := context.WithTimeout(context.Background(), 15*time.Second)
-
-	//HACK:
-	ctx, cancel := chromedp.NewContext(cctx)
-	//ctx, cancel := chromedp.NewContext(context.Background())
+	ctx, cancel := chromedp.NewContext(context.Background())
 	defer cancel()
-	defer ccancel()
 
 	var buf []byte
 
@@ -237,7 +231,6 @@ func (ex *extras) toBytes(data ConvertParam, res *[]byte) chromedp.Tasks {
 
 			*res = buf
 			return nil
-
 		}),
 	}
 }

--- a/extras.go
+++ b/extras.go
@@ -158,7 +158,7 @@ func (ex *extras) htmlToX(w http.ResponseWriter, r *http.Request) {
 	var buf []byte
 
 	if err := chromedp.Run(ctx, ex.toBytes(data, &buf)); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("htmltox chromedp run %s", err.Error()), http.StatusInternalServerError)
 		return
 	}
 

--- a/extras.go
+++ b/extras.go
@@ -158,7 +158,7 @@ func (ex *extras) htmlToX(w http.ResponseWriter, r *http.Request) {
 	var buf []byte
 
 	if err := chromedp.Run(ctx, ex.toBytes(data, &buf)); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("htmltox chromedp run %s"err.Error()), http.StatusInternalServerError)
 		return
 	}
 

--- a/extras_test.go
+++ b/extras_test.go
@@ -111,13 +111,11 @@ func TestSudoSendSMS(t *testing.T) {
 		t.Log(string(b))
 		t.Errorf("expected status 200 got %s", resp.Status)
 	}
-
 }
 
 func TestHtmlToPDF(t *testing.T) {
 	// TODO: this is intermitant and when it failes it's with that
 	// error line:128: context deadline exceeded
-	t.Skip()
 
 	data := ConvertParam{
 		ToPDF: true,
@@ -136,7 +134,6 @@ func TestHtmlToPDF(t *testing.T) {
 		t.Log(string(b))
 		t.Errorf("expected status 200 got %s", resp.Status)
 	}
-
 }
 
 func TestHtmlToPNG(t *testing.T) {
@@ -144,7 +141,6 @@ func TestHtmlToPNG(t *testing.T) {
 	// error: extras_test.go:157: context deadline exceeded
 	//
 	// we need to determine why it's doing this and remove the Skip
-	t.Skip()
 
 	data := ConvertParam{
 		ToPDF:    false,
@@ -164,5 +160,4 @@ func TestHtmlToPNG(t *testing.T) {
 		t.Log(string(b))
 		t.Errorf("expected status 200 got %s", resp.Status)
 	}
-
 }


### PR DESCRIPTION
Fixes #38
- Remove context timeout for chrome on htmltox func.
- Allow tests related to htmltox to run
- Make chrome run error for htmltox more verbose 