### PR TITLE
Cleanup database provider tests

### DIFF
--- a/database/dbtest/dbtest.go
+++ b/database/dbtest/dbtest.go
@@ -1,0 +1,68 @@
+package dbtest
+
+import (
+	"testing"
+
+	"github.com/staticbackendhq/core/database"
+	"github.com/staticbackendhq/core/model"
+)
+
+const (
+	adminEmail    = "pg@test.com"
+	adminPassword = "test1234!"
+	confDBName    = "testdb"
+	colName       = "tasks"
+)
+
+func FindToken(t *testing.T, datastore database.Persister, adminToken model.User) {
+	tok, err := datastore.FindUser(confDBName, adminToken.ID, adminToken.Token)
+	if err != nil {
+		t.Fatal(err)
+	} else if tok.ID != adminToken.ID {
+		t.Errorf("expected tok.id to be %s got %s", adminToken.ID, tok.ID)
+	}
+}
+
+func FindRootToken(t *testing.T, datastore database.Persister, adminToken model.User) {
+	tok, err := datastore.FindRootUser(confDBName, adminToken.ID, adminToken.AccountID, adminToken.Token)
+	if err != nil {
+		t.Fatal(err)
+	} else if tok.ID != adminToken.ID {
+		t.Errorf("expected token id to be %s got %s", adminToken.ID, tok.ID)
+	}
+}
+
+func GetRootForBase(t *testing.T, datastore database.Persister, adminToken model.User) {
+	tok, err := datastore.GetRootForBase(confDBName)
+	if err != nil {
+		t.Fatal(err)
+	} else if tok.ID != adminToken.ID {
+		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
+	}
+}
+
+func FindTokenByEmail(t *testing.T, datastore database.Persister, adminToken model.User) {
+	tok, err := datastore.FindUserByEmail(confDBName, adminEmail)
+	if err != nil {
+		t.Fatal(err)
+	} else if tok.ID != adminToken.ID {
+		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
+	}
+}
+
+func UserEmailExists(t *testing.T, datastore database.Persister) {
+	if exists, err := datastore.UserEmailExists(confDBName, adminEmail); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Errorf("email should exists")
+	}
+}
+
+func AccountList(t *testing.T, datastore database.Persister) {
+	accts, err := datastore.ListAccounts(confDBName)
+	if err != nil {
+		t.Fatal(err)
+	} else if len(accts) == 0 {
+		t.Errorf("expected at least 1 account, got %d", len(accts))
+	}
+}

--- a/database/memory/account_test.go
+++ b/database/memory/account_test.go
@@ -1,56 +1,31 @@
 package memory
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/staticbackendhq/core/database/dbtest"
+)
 
 func TestFindToken(t *testing.T) {
-	tok, err := datastore.FindUser(confDBName, adminToken.ID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok.id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindToken(t, datastore, adminToken)
 }
 
 func TestFindRootToken(t *testing.T) {
-	tok, err := datastore.FindRootUser(confDBName, adminToken.ID, adminToken.AccountID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected token id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindRootToken(t, datastore, adminToken)
 }
 
 func TestGetRootForBase(t *testing.T) {
-	tok, err := datastore.GetRootForBase(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.GetRootForBase(t, datastore, adminToken)
 }
 
 func TestFindTokenByEmail(t *testing.T) {
-	tok, err := datastore.FindUserByEmail(confDBName, adminEmail)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindTokenByEmail(t, datastore, adminToken)
 }
 
 func TestUserEmailExists(t *testing.T) {
-	if exists, err := datastore.UserEmailExists(confDBName, adminEmail); err != nil {
-		t.Fatal(err)
-	} else if !exists {
-		t.Errorf("email should exists")
-	}
+	dbtest.UserEmailExists(t, datastore)
 }
 
 func TestAccountList(t *testing.T) {
-	accts, err := datastore.ListAccounts(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(accts) == 0 {
-		t.Errorf("expected at least 1 account, got %d", len(accts))
-	}
+	dbtest.AccountList(t, datastore)
 }

--- a/database/mongo/account_test.go
+++ b/database/mongo/account_test.go
@@ -1,56 +1,31 @@
 package mongo
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/staticbackendhq/core/database/dbtest"
+)
 
 func TestFindToken(t *testing.T) {
-	tok, err := datastore.FindUser(confDBName, adminToken.ID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok.id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindToken(t, datastore, adminToken)
 }
 
 func TestFindRootToken(t *testing.T) {
-	tok, err := datastore.FindRootUser(confDBName, adminToken.ID, adminToken.AccountID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected token id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindRootToken(t, datastore, adminToken)
 }
 
 func TestGetRootForBase(t *testing.T) {
-	tok, err := datastore.GetRootForBase(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.GetRootForBase(t, datastore, adminToken)
 }
 
 func TestFindTokenByEmail(t *testing.T) {
-	tok, err := datastore.FindUserByEmail(confDBName, adminEmail)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindTokenByEmail(t, datastore, adminToken)
 }
 
 func TestUserEmailExists(t *testing.T) {
-	if exists, err := datastore.UserEmailExists(confDBName, adminEmail); err != nil {
-		t.Fatal(err)
-	} else if !exists {
-		t.Errorf("email should exists")
-	}
+	dbtest.UserEmailExists(t, datastore)
 }
 
 func TestAccountList(t *testing.T) {
-	accts, err := datastore.ListAccounts(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(accts) == 0 {
-		t.Errorf("expected at least 1 account, got %d", len(accts))
-	}
+	dbtest.AccountList(t, datastore)
 }

--- a/database/postgresql/account_test.go
+++ b/database/postgresql/account_test.go
@@ -1,56 +1,31 @@
 package postgresql
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/staticbackendhq/core/database/dbtest"
+)
 
 func TestFindToken(t *testing.T) {
-	tok, err := datastore.FindUser(confDBName, adminToken.ID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok.id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindToken(t, datastore, adminToken)
 }
 
 func TestFindRootToken(t *testing.T) {
-	tok, err := datastore.FindRootUser(confDBName, adminToken.ID, adminToken.AccountID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected token id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindRootToken(t, datastore, adminToken)
 }
 
 func TestGetRootForBase(t *testing.T) {
-	tok, err := datastore.GetRootForBase(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.GetRootForBase(t, datastore, adminToken)
 }
 
 func TestFindTokenByEmail(t *testing.T) {
-	tok, err := datastore.FindUserByEmail(confDBName, adminEmail)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindTokenByEmail(t, datastore, adminToken)
 }
 
 func TestUserEmailExists(t *testing.T) {
-	if exists, err := datastore.UserEmailExists(confDBName, adminEmail); err != nil {
-		t.Fatal(err)
-	} else if !exists {
-		t.Errorf("email should exists")
-	}
+	dbtest.UserEmailExists(t, datastore)
 }
 
 func TestAccountList(t *testing.T) {
-	accts, err := datastore.ListAccounts(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(accts) == 0 {
-		t.Errorf("expected at least 1 account, got %d", len(accts))
-	}
+	dbtest.AccountList(t, datastore)
 }

--- a/database/sqlite/account_test.go
+++ b/database/sqlite/account_test.go
@@ -2,57 +2,30 @@ package sqlite
 
 import (
 	"testing"
+
+	"github.com/staticbackendhq/core/database/dbtest"
 )
 
 func TestFindToken(t *testing.T) {
-	tok, err := datastore.FindUser(confDBName, adminToken.ID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok.id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindToken(t, datastore, adminToken)
 }
 
 func TestFindRootToken(t *testing.T) {
-	tok, err := datastore.FindRootUser(confDBName, adminToken.ID, adminToken.AccountID, adminToken.Token)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected token id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindRootToken(t, datastore, adminToken)
 }
 
 func TestGetRootForBase(t *testing.T) {
-	tok, err := datastore.GetRootForBase(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.GetRootForBase(t, datastore, adminToken)
 }
 
 func TestFindTokenByEmail(t *testing.T) {
-	tok, err := datastore.FindUserByEmail(confDBName, adminEmail)
-	if err != nil {
-		t.Fatal(err)
-	} else if tok.ID != adminToken.ID {
-		t.Errorf("expected tok id to be %s got %s", adminToken.ID, tok.ID)
-	}
+	dbtest.FindTokenByEmail(t, datastore, adminToken)
 }
 
 func TestUserEmailExists(t *testing.T) {
-	if exists, err := datastore.UserEmailExists(confDBName, adminEmail); err != nil {
-		t.Fatal(err)
-	} else if !exists {
-		t.Errorf("email should exists")
-	}
+	dbtest.UserEmailExists(t, datastore)
 }
 
 func TestAccountList(t *testing.T) {
-	accts, err := datastore.ListAccounts(confDBName)
-	if err != nil {
-		t.Fatal(err)
-	} else if len(accts) == 0 {
-		t.Errorf("expected at least 1 account, got %d", len(accts))
-	}
+	dbtest.AccountList(t, datastore)
 }


### PR DESCRIPTION
Hi. I'm opening this to initiate a discussion on #80.  By introducing a common `dbtest` package, you could drastically reduce the amount of code required in the `*_test.go` files.

For example:

```go
package memory

import (
	"testing"

	"github.com/staticbackendhq/core/database/dbtest"
)

func TestFindToken(t *testing.T) {
	dbtest.FindToken(t, datastore, adminToken)
}

func TestFindRootToken(t *testing.T) {
	dbtest.FindRootToken(t, datastore, adminToken)
}

func TestGetRootForBase(t *testing.T) {
	dbtest.GetRootForBase(t, datastore, adminToken)
}

func TestFindTokenByEmail(t *testing.T) {
	dbtest.FindTokenByEmail(t, datastore, adminToken)
}

func TestUserEmailExists(t *testing.T) {
	dbtest.UserEmailExists(t, datastore)
}

func TestAccountList(t *testing.T) {
	dbtest.AccountList(t, datastore)
}
```
If you like this approach, I'd be happy to apply this for all database provider tests.